### PR TITLE
Add configuration for netlify deploy previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+farmOS.org/

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  publish = "farmOS.org/public/"
+  command = "npm run build-preview"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex"

--- a/netlifyGetRepoUrl.js
+++ b/netlifyGetRepoUrl.js
@@ -1,0 +1,16 @@
+import fetch from 'node-fetch'
+
+const getPullRequestRepoUrl = async () => {
+  if (process.env.PULL_REQUEST) {
+    const repoUrl = process.env.REPOSITORY_URL
+    const repoName = repoUrl.replace("https://github.com/", "")
+    const branch = process.env.BRANCH
+    const pullRequest = branch.replace("pull/", "").replace("/head", "")
+    const response = await fetch(`https://api.github.com/repos/${repoName}/pulls/${pullRequest}`)
+    const prInfo = await response.json()
+    console.log(prInfo.head.repo.clone_url)
+    return
+  }
+  console.log(process.env.HEAD)
+}
+getPullRequestRepoUrl()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "farmos-community-blog",
+  "type": "module",
+  "scripts": {
+    "build-preview": "rm -rf farmOS.org && git clone --depth=1 https://github.com/farmOS/farmOS.org && cd farmOS.org && npm i && BLOG_REPO=$(node ../netlifyGetRepoUrl.js) BLOG_REPO_BRANCH=$HEAD npm run build"
+  },
+  "devDependencies": {
+    "node-fetch": "^3.3.0"
+  }
+}


### PR DESCRIPTION
This pr adds configuration needed to setup deploy previews for pull requests in this repo.

Netlify sites are very coupled to the specific repo and its branches, so the easiest way to configure deploy previews is to setup this repo as a netlify site. To this end I created a build configuration that temporarily copies the main site repo and using [repo/branch overrides](https://github.com/farmOS/farmOS.org/pull/68) builds the site with the blog source replaced with the pr repo/branch. Netlify doesn't have an existing env var for pr source repo, so to get it's url I created a small script that queries github api for pr details. I also added netlify configuration to set http header telling search engines to don't index this repo's site.

After merging this, netlify site for this repo will need to be created. Just creating a site without changing any defaults should be enough, any additional required netlify configuration is handled using the `netlify.toml` file.