### PR TITLE
update nodejs version used to build deploy previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   publish = "farmOS.org/public/"
   command = "npm run build-preview"
+  environment = { NODE_VERSION = "18" }
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
Sets Node.js version used to build deploy previews to be inline with [the version required to build the site](https://github.com/farmOS/farmOS.org/blob/main/netlify.toml#L3C1-L3C38).
This fixes building deploy previews on pull requests that [seem to be broken](https://app.netlify.com/sites/farmos-community-blog-preview/deploys/64d3a441e6c5ba0008a841be#L319) after https://github.com/farmOS/farmOS.org/pull/79 was merged.
