### PR TITLE
Repost GOAT 2024 applications newsletter

### DIFF
--- a/posts/2024/goat-2024-applications-open/index.md
+++ b/posts/2024/goat-2024-applications-open/index.md
@@ -1,0 +1,43 @@
+---
+title: GOAT 2024 Applications are Open
+date: 2024-08-01
+author: Michael Stenta
+slug: 2024/goat-2024-applications-open
+categories:
+  - newsletter
+---
+
+# GOAT 2024 Application is LIVE through 8/30
+
+(This is a repost from the [GOAT](https://goatech.org/) mailing list.)
+
+Hello GOAT Community!
+
+[GOAT 2024](https://goatech.org/2024/07/08/goat-2024/) is back and will take
+place during the week of Sunday, November 3rd through Friday, November 8th at
+[Paicines Ranch](https://paicinesranch.com/) in Paicines, California. The
+beautiful Paicines Ranch is located about 60 miles south of San Jose, and we
+will arrange shuttles for folks to get to/from the venue.
+
+Since 2018, GOAT has brought together a diverse range of practitioners -
+including farmers, designers, agronomists, activists, and researchers - to
+advocate for more accessible software and hardware with full control going to
+the farmers, eaters, and everyday users. The gathering is mostly in the format
+of an "unconference," where the majority of sessions are created and scheduled
+by the participants on-site when they first arrive. Topics can vary from
+software architecture and farming practices to algorithmic justice and climate
+resilience. Take a look on the forum under the
+[#session](https://forum.goatech.org/tag/session) tag for examples of past
+sessions.
+
+[The application](https://docs.google.com/forms/d/e/1FAIpQLScl0-aO2Ip28OIKR5l3g0CyZjgaIgrsaG3IHRsxFk4eR9AfTA/closedform)
+for 2024's gathering is LIVE and will be open until August 30th. Applicants
+will be notified by September 13th of their acceptance and will have until
+September 27th to register for the conference.
+
+*&ast; please note that the general election is happening during the GOAT conference,
+we encourage everyone to make absentee or early voting plans!*
+
+Sincerely,
+\
+GOAT Herders 2024


### PR DESCRIPTION
This newsletter was sent out by [GOAT](https://goatech.org/) for the 2024 conference. This would repost it to the farmOS blog and send it out via our newsletter so that our community is aware.